### PR TITLE
Implement WOFF2

### DIFF
--- a/fira.css
+++ b/fira.css
@@ -3,6 +3,7 @@
     src: url('eot/FiraSans-Hair.eot');
     src: local('Fira Sans Hair'),
          url('eot/FiraSans-Hair.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-Hair.woff2') format('woff2'),
          url('woff/FiraSans-Hair.woff') format('woff'),
          url('ttf/FiraSans-Hair.ttf') format('truetype');
     font-weight: 100;
@@ -14,6 +15,7 @@
     src: url('eot/FiraSans-HairItalic.eot');
     src: local('Fira Sans Hair Italic'),
          url('eot/FiraSans-HairItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-HairItalic.woff2') format('woff2'),
          url('woff/FiraSans-HairItalic.woff') format('woff'),
          url('ttf/FiraSans-HairItalic.ttf') format('truetype');
     font-weight: 100;
@@ -25,6 +27,7 @@
     src: url('eot/FiraSans-UltraLight.eot');
     src: local('Fira Sans UltraLight'),
          url('eot/FiraSans-UltraLight.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-UltraLight.woff2') format('woff2'),
          url('woff/FiraSans-UltraLight.woff') format('woff'),
          url('ttf/FiraSans-UltraLight.ttf') format('truetype');
     font-weight: 200;
@@ -36,6 +39,7 @@
     src: url('eot/FiraSans-UltraLightItalic.eot');
     src: local('Fira Sans UltraLight Italic'),
          url('eot/FiraSans-UltraLightItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-UltraLightItalic.woff2') format('woff2'),
          url('woff/FiraSans-UltraLightItalic.woff') format('woff'),
          url('ttf/FiraSans-UltraLightItalic.ttf') format('truetype');
     font-weight: 200;
@@ -47,6 +51,7 @@
     src: url('eot/FiraSans-Light.eot');
     src: local('Fira Sans Light'),
          url('eot/FiraSans-Light.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-Light.woff2') format('woff2'),
          url('woff/FiraSans-Light.woff') format('woff'),
          url('ttf/FiraSans-Light.ttf') format('truetype');
     font-weight: 300;
@@ -58,6 +63,7 @@
     src: url('eot/FiraSans-LightItalic.eot');
     src: local('Fira Sans Light Italic'),
          url('eot/FiraSans-LightItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-LightItalic.woff2') format('woff2'),
          url('woff/FiraSans-LightItalic.woff') format('woff'),
          url('ttf/FiraSans-LightItalic.ttf') format('truetype');
     font-weight: 300;
@@ -69,6 +75,7 @@
     src: url('eot/FiraSans-Regular.eot');
     src: local('Fira Sans Regular'),
          url('eot/FiraSans-Regular.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-Regular.woff2') format('woff2'),
          url('woff/FiraSans-Regular.woff') format('woff'),
          url('ttf/FiraSans-Regular.ttf') format('truetype');
     font-weight: 400;
@@ -80,6 +87,7 @@
     src: url('eot/FiraSans-Italic.eot');
     src: local('Fira Sans Regular Italic'),
          url('eot/FiraSans-Italic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-Italic.woff2') format('woff2'),
          url('woff/FiraSans-Italic.woff') format('woff'),
          url('ttf/FiraSans-Italic.ttf') format('truetype');
     font-weight: 400;
@@ -91,6 +99,7 @@
     src: url('eot/FiraSans-Medium.eot');
     src: local('Fira Sans Medium'),
          url('eot/FiraSans-Medium.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-Medium.woff2') format('woff2'),
          url('woff/FiraSans-Medium.woff') format('woff'),
          url('ttf/FiraSans-Medium.ttf') format('truetype');
     font-weight: 500;
@@ -102,6 +111,7 @@
     src: url('eot/FiraSans-MediumItalic.eot');
     src: local('Fira Sans Medium Italic'),
          url('eot/FiraSans-MediumItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-MediumItalic.woff2') format('woff2'),
          url('woff/FiraSans-MediumItalic.woff') format('woff'),
          url('ttf/FiraSans-MediumItalic.ttf') format('truetype');
     font-weight: 500;
@@ -113,6 +123,7 @@
     src: url('eot/FiraSans-SemiBold.eot');
     src: local('Fira Sans SemiBold'),
          url('eot/FiraSans-SemiBold.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-SemiBold.woff2') format('woff2'),
          url('woff/FiraSans-SemiBold.woff') format('woff'),
          url('ttf/FiraSans-SemiBold.ttf') format('truetype');
     font-weight: 600;
@@ -124,6 +135,7 @@
     src: url('eot/FiraSans-SemiBoldItalic.eot');
     src: local('Fira Sans SemiBold Italic'),
          url('eot/FiraSans-SemiBoldItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-SemiBoldItalic.woff2') format('woff2'),
          url('woff/FiraSans-SemiBoldItalic.woff') format('woff'),
          url('ttf/FiraSans-SemiBoldItalic.ttf') format('truetype');
     font-weight: 600;
@@ -135,6 +147,7 @@
     src: url('eot/FiraSans-Bold.eot');
     src: local('Fira Sans Bold'),
          url('eot/FiraSans-Bold.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-Bold.woff2') format('woff2'),
          url('woff/FiraSans-Bold.woff') format('woff'),
          url('ttf/FiraSans-Bold.ttf') format('truetype');
     font-weight: 700;
@@ -146,6 +159,7 @@
     src: url('eot/FiraSans-BoldItalic.eot');
     src: local('Fira Sans Bold Italic'),
          url('eot/FiraSans-BoldItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-BoldItalic.woff2') format('woff2'),
          url('woff/FiraSans-BoldItalic.woff') format('woff'),
          url('ttf/FiraSans-BoldItalic.ttf') format('truetype');
     font-weight: 700;
@@ -157,6 +171,7 @@
     src: url('eot/FiraSans-ExtraBold.eot');
     src: local('Fira Sans ExtraBold'),
          url('eot/FiraSans-ExtraBold.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-ExtraBold.woff2') format('woff2'),
          url('woff/FiraSans-ExtraBold.woff') format('woff'),
          url('ttf/FiraSans-ExtraBold.ttf') format('truetype');
     font-weight: 800;
@@ -168,6 +183,7 @@
     src: url('eot/FiraSans-ExtraBoldItalic.eot');
     src: local('Fira Sans ExtraBold Italic'),
          url('eot/FiraSans-ExtraBoldItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-ExtraBoldItalic.woff2') format('woff2'),
          url('woff/FiraSans-ExtraBoldItalic.woff') format('woff'),
          url('ttf/FiraSans-ExtraBoldItalic.ttf') format('truetype');
     font-weight: 800;
@@ -179,6 +195,7 @@
     src: url('eot/FiraSans-Heavy.eot');
     src: local('Fira Sans Heavy'),
          url('eot/FiraSans-Heavy.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-Heavy.woff2') format('woff2'),
          url('woff/FiraSans-Heavy.woff') format('woff'),
          url('ttf/FiraSans-Heavy.ttf') format('truetype');
     font-weight: 900;
@@ -190,6 +207,7 @@
     src: url('eot/FiraSans-HeavyItalic.eot');
     src: local('Fira Sans Heavy Italic'),
          url('eot/FiraSans-HeavyItalic.eot') format('embedded-opentype'),
+         url('woff2/FiraSans-HeavyItalic.woff2') format('woff2'),
          url('woff/FiraSans-HeavyItalic.woff') format('woff'),
          url('ttf/FiraSans-HeavyItalic.ttf') format('truetype');
     font-weight: 900;
@@ -202,6 +220,7 @@
     src: url('eot/FiraMono-Regular.eot');
     src: local('Fira Mono'),
          url('eot/FiraMono-Regular.eot') format('embedded-opentype'),
+         url('woff2/FiraMono-Regular.woff2') format('woff2'),
          url('woff/FiraMono-Regular.woff') format('woff'),
          url('ttf/FiraMono-Regular.ttf') format('truetype');
     font-weight: 400;
@@ -213,6 +232,7 @@
     src: url('eot/FiraMono-Bold.eot');
     src: local('Fira Mono Bold'),
          url('eot/FiraMono-Bold.eot') format('embedded-opentype'),
+         url('woff2/FiraMono-Bold.woff2') format('woff2'),
          url('woff/FiraMono-Bold.woff') format('woff'),
          url('ttf/FiraMono-Bold.ttf') format('truetype');
     font-weight: 600;


### PR DESCRIPTION
- <http://caniuse.com/#feat=woff2>
- <https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a>

Maybe check on the CDN:
> Think about the correct mime type for WOFF 2.0 files (Google uses font/woff2. W3C recommends application/font-woff2):