### PR TITLE
Encourage HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ If you're interested in contributing, see our  <a href="https://docs.google.com/
 Use this font on your website!
 
 ```html
-<link rel="stylesheet" href="//code.cdn.mozilla.net/fonts/fira.css">
+<link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
 ```


### PR DESCRIPTION
Encourage HTTPS as protocol-relative URL is deprecated.
See <http://www.paulirish.com/2010/the-protocol-relative-url/>.

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset.