### PR TITLE
include woff2 in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "otf",
     "ttf",
     "woff",
+    "woff2",
     "LICENSE",
     "fira.css"
   ],


### PR DESCRIPTION
When grabbing this repo as dependency via npm, the woff2 folder is missing. This PR makes the woff2 folder be included when installed via npm.