### PR TITLE
Publish stylesheets for pre-processors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,10 @@
 {
   "name": "fira",
-  "main": "fira.css"
+  "main": [
+    "fira.css",
+    "fira.less",
+    "fira.sass",
+    "fira.scss",
+    "fira.styl"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,18 @@
     "woff",
     "woff2",
     "LICENSE",
+    "fira-sans.less",
+    "fira-mono.less",
+    "fira.less",
+    "fira-sans.sass",
+    "fira-mono.sass",
+    "fira.sass",
+    "fira-sans.scss",
+    "fira-mono.scss",
+    "fira.scss",
+    "fira-sans.styl",
+    "fira-mono.styl",
+    "fira.styl",
     "fira.css"
   ],
   "dependencies": {


### PR DESCRIPTION
This change makes sure pre-processor stylesheets gets published so package consumers can take advantage of them.

This depends on #175 to actually be useful for sass and stylus languages.
