### PR TITLE
fira-sans.*: Rename “FiraSans-RegularItalic” to “FiraSans-Italic”

### DIFF
--- a/fira-sans.less
+++ b/fira-sans.less
@@ -35,11 +35,11 @@
 
 @font-face{
     font-family: 'Fira Sans';
-    src: url('eot/FiraSans-RegularItalic.eot');
+    src: url('eot/FiraSans-Italic.eot');
     src: local('Fira Sans Regular Italic'),
-         url('eot/FiraSans-RegularItalic.eot') format('embedded-opentype'),
-         url('woff/FiraSans-RegularItalic.woff') format('woff'),
-         url('ttf/FiraSans-RegularItalic.ttf') format('truetype');
+         url('eot/FiraSans-Italic.eot') format('embedded-opentype'),
+         url('woff/FiraSans-Italic.woff') format('woff'),
+         url('ttf/FiraSans-Italic.ttf') format('truetype');
     font-weight: 400;
     font-style: italic;
 }

--- a/fira-sans.sass
+++ b/fira-sans.sass
@@ -23,8 +23,8 @@
 
 @font-face
   font-family: 'Fira Sans'
-  src: url("eot/FiraSans-RegularItalic.eot")
-  src: local("Fira Sans Regular Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
+  src: url("eot/FiraSans-Italic.eot")
+  src: local("Fira Sans Regular Italic"), url("eot/FiraSans-Italic.eot") format("embedded-opentype"), url("woff/FiraSans-Italic.woff") format("woff"), url("ttf/FiraSans-Italic.ttf") format("truetype")
   font-weight: 400
   font-style: italic
 

--- a/fira-sans.scss
+++ b/fira-sans.scss
@@ -35,11 +35,11 @@
 
 @font-face{
     font-family: 'Fira Sans';
-    src: url("eot/FiraSans-RegularItalic.eot");
+    src: url("eot/FiraSans-Italic.eot");
     src: local("Fira Sans Regular Italic"),
-         url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"),
-         url("woff/FiraSans-RegularItalic.woff") format("woff"),
-         url("ttf/FiraSans-RegularItalic.ttf") format("truetype");
+         url("eot/FiraSans-Italic.eot") format("embedded-opentype"),
+         url("woff/FiraSans-Italic.woff") format("woff"),
+         url("ttf/FiraSans-Italic.ttf") format("truetype");
     font-weight: 400;
     font-style: italic;
 }

--- a/fira-sans.styl
+++ b/fira-sans.styl
@@ -23,8 +23,8 @@
 
 @font-face
   font-family: 'Fira Sans'
-  src: url("eot/FiraSans-RegularItalic.eot")
-  src: local("Fira Sans Regular Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
+  src: url("eot/FiraSans-Italic.eot")
+  src: local("Fira Sans Regular Italic"), url("eot/FiraSans-Italic.eot") format("embedded-opentype"), url("woff/FiraSans-Italic.woff") format("woff"), url("ttf/FiraSans-Italic.ttf") format("truetype")
   font-weight: 400
   font-style: italic
 


### PR DESCRIPTION
Since commit 317e6c0d9a06c9b9db2a7b1281ccb7e8f983cd98 (and then d6d05bf47955a36aab5d66319882b17b95944d92), the fonts “FiraSans-RegularItalic” have disappeared since they were the same files as the “FiraSans-Italic” series. But it seems that the files from CSS frameworks (Less, Sass, Scss and Styl) have not been updated.

This commit updates the names so that inclusion of the files for regular italic flavor of the fonts works properly.
