### PR TITLE
fira-sans.*: local font “Fira Sans Regular *” → “Fira Sans *”

### DIFF
--- a/fira-sans.less
+++ b/fira-sans.less
@@ -25,7 +25,7 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url('eot/FiraSans-Regular.eot');
-    src: local('Fira Sans Regular'),
+    src: local('Fira Sans'),
          url('eot/FiraSans-Regular.eot') format('embedded-opentype'),
          url('woff/FiraSans-Regular.woff') format('woff'),
          url('ttf/FiraSans-Regular.ttf') format('truetype');
@@ -36,7 +36,7 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url('eot/FiraSans-RegularItalic.eot');
-    src: local('Fira Sans Regular Italic'),
+    src: local('Fira Sans Italic'),
          url('eot/FiraSans-RegularItalic.eot') format('embedded-opentype'),
          url('woff/FiraSans-RegularItalic.woff') format('woff'),
          url('ttf/FiraSans-RegularItalic.ttf') format('truetype');

--- a/fira-sans.sass
+++ b/fira-sans.sass
@@ -17,14 +17,14 @@
 @font-face
   font-family: 'Fira Sans'
   src: url("eot/FiraSans-Regular.eot")
-  src: local("Fira Sans Regular"), url("eot/FiraSans-Regular.eot") format("embedded-opentype"), url("woff/FiraSans-Regular.woff") format("woff"), url("ttf/FiraSans-Regular.ttf") format("truetype")
+  src: local("Fira Sans"), url("eot/FiraSans-Regular.eot") format("embedded-opentype"), url("woff/FiraSans-Regular.woff") format("woff"), url("ttf/FiraSans-Regular.ttf") format("truetype")
   font-weight: 400
   font-style: normal
 
 @font-face
   font-family: 'Fira Sans'
   src: url("eot/FiraSans-RegularItalic.eot")
-  src: local("Fira Sans Regular Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
+  src: local("Fira Sans Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
   font-weight: 400
   font-style: italic
 

--- a/fira-sans.scss
+++ b/fira-sans.scss
@@ -25,7 +25,7 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url("eot/FiraSans-Regular.eot");
-    src: local("Fira Sans Regular"),
+    src: local("Fira Sans"),
          url("eot/FiraSans-Regular.eot") format("embedded-opentype"),
          url("woff/FiraSans-Regular.woff") format("woff"),
          url("ttf/FiraSans-Regular.ttf") format("truetype");
@@ -36,7 +36,7 @@
 @font-face{
     font-family: 'Fira Sans';
     src: url("eot/FiraSans-RegularItalic.eot");
-    src: local("Fira Sans Regular Italic"),
+    src: local("Fira Sans Italic"),
          url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"),
          url("woff/FiraSans-RegularItalic.woff") format("woff"),
          url("ttf/FiraSans-RegularItalic.ttf") format("truetype");

--- a/fira-sans.styl
+++ b/fira-sans.styl
@@ -17,14 +17,14 @@
 @font-face
   font-family: 'Fira Sans'
   src: url("eot/FiraSans-Regular.eot")
-  src: local("Fira Sans Regular"), url("eot/FiraSans-Regular.eot") format("embedded-opentype"), url("woff/FiraSans-Regular.woff") format("woff"), url("ttf/FiraSans-Regular.ttf") format("truetype")
+  src: local("Fira Sans"), url("eot/FiraSans-Regular.eot") format("embedded-opentype"), url("woff/FiraSans-Regular.woff") format("woff"), url("ttf/FiraSans-Regular.ttf") format("truetype")
   font-weight: 400
   font-style: normal
 
 @font-face
   font-family: 'Fira Sans'
   src: url("eot/FiraSans-RegularItalic.eot")
-  src: local("Fira Sans Regular Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
+  src: local("Fira Sans Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
   font-weight: 400
   font-style: italic
 


### PR DESCRIPTION
At least under Linux (Ubuntu), the regular and regular italic system fonts are recognized as “Fira Sans” and “Fira Sans Italic”, while the stylesheets for CSS pre-processors call them as “Fira Sans Regular” and “Fira Sans Regular Italic”, respectively.

This commit fixes the names by removing the “Regular” part.

Note that I do not know how fonts are treated on other systems (it might be worth checking that this commit does not breaks things under Windows?)
