### PR TITLE
Add more information to bower.json and ignore files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,25 @@
 {
   "name": "fira",
-  "main": "fira.css"
+  "description": "Fira font family including Fira Sans and Fira Mono",
+  "main": "fira.css",
+  "authors": [
+    "The Mozilla Foundation and Telefonica S.A."
+  ],
+  "license": "OFL-1.1",
+  "keywords": [
+    "fonts",
+    "fira",
+    "firefox",
+    "os",
+    "css",
+    "mozilla"
+  ],
+  "homepage": "https://mozilla.github.io/Fira/",
+  "ignore": [
+    "Fira_Version_Report.md",
+    "index.html",
+    "package.json",
+    "source/",
+    "technical reports/"
+  ]
 }


### PR DESCRIPTION
- Adds some more information to the bower package
- Ignores files which are not needed for the bower package
As requested here: https://github.com/mozilla/Fira/pull/52#issuecomment-67426238
I think we don't need `source` and `technical reports` in the bower
package. It's very annoying to download all the PDFs and sources every
time...