### PR TITLE
fix(readme): markdown changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-#Mozilla's Fira Type Family
+# Mozilla's Fira Type Family
 http://mozilla.github.io/Fira/
 
-##Download Fira
+## Download Fira
 <a href="https://github.com/mozilla/Fira/releases/latest">Latest Release</a><br>
 <a href="https://github.com/mozilla/Fira/releases">All Releases</a>
 
-##Fira Roadmap
+## Fira Roadmap
 See the  <a href="https://docs.google.com/document/d/1fLxzQsULTv43umIhpB9Gv3Gi7aOBONHbqEbwZIipmxw/edit">Fira Road Map</a> for further information on upcoming releases. Please add your comments or questions within the document.
 
 
-##How to Contribute to Fira
+## How to Contribute to Fira
 If you're interested in contributing, see our  <a href="https://docs.google.com/document/d/1QfxweGktJEdBvbd94y-5hiyqu32U9-h_ICPVs76Niyw/edit">Fira Contribution Documentation</a>. Please add your comments or questions within the document.
 
 
-##Usage
+## Usage
 Use this font on your website!
 
 ```html
 <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
 ```
 
-##External Resources
+## External Resources
 Further information on the design and specifications of the Fira typeface can be found at <a href="https://carrois.com/typefaces/FiraSans/">Carrois Studio</a>.<br>
 Fira can also be found in these foundries:<br>
 <a href="http://www.1001fonts.com/fira-sans-font.html">1001 Fonts<br>


### PR DESCRIPTION
GitHub changed its markdown implementation, and it only allows headers with a space after the hash.