### PR TITLE
Point to font foundry repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+We've Moved!
+============
+
+Development of Fira has moved to the [Carrois repository](https://github.com/carrois/Fira), please submit contributions there.
+
 # Mozilla's Fira Type Family
 http://mozilla.github.io/Fira/
 


### PR DESCRIPTION
As per [#210](https://github.com/carrois/Fira), this repo is no longer being maintained.  Updated README to reflect that latest development has transitioned to the foundry originally commissioned to create Fira.