### PR TITLE
Add font-display property

### DIFF
--- a/fira-mono.less
+++ b/fira-mono.less
@@ -1,4 +1,5 @@
 /* Fira Mono specimen */
+@font-display: swap;
 
 @font-face{
     font-family: 'Fira Mono';
@@ -9,6 +10,7 @@
          url('ttf/FiraMono-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -20,4 +22,5 @@
          url('ttf/FiraMono-Bold.ttf') format('truetype');
     font-weight: 600;
     font-style: normal;
+    font-display: @font-display;
 }

--- a/fira-mono.sass
+++ b/fira-mono.sass
@@ -1,4 +1,5 @@
 // Fira Mono
+$font-display: swap !default
 
 @font-face
   font-family: 'Fira Mono'
@@ -6,6 +7,7 @@
   src: local("Fira Mono"), url("eot/FiraMono-Regular.eot") format("embedded-opentype"), url("woff/FiraMono-Regular.woff") format("woff"), url("ttf/FiraMono-Regular.ttf") format("truetype")
   font-weight: 400
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Mono'
@@ -13,4 +15,5 @@
   src: local("Fira Mono Bold"), url("eot/FiraMono-Bold.eot") format("embedded-opentype"), url("woff/FiraMono-Bold.woff") format("woff"), url("ttf/FiraMono-Bold.ttf") format("truetype")
   font-weight: 600
   font-style: normal
+  font-display: $font-display
 

--- a/fira-mono.scss
+++ b/fira-mono.scss
@@ -1,4 +1,5 @@
 // Fira Mono
+$font-display: swap !default;
 
 @font-face{
     font-family: 'Fira Mono';
@@ -9,6 +10,7 @@
          url("ttf/FiraMono-Regular.ttf") format("truetype");
     font-weight: 400;
     font-style: normal;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -20,5 +22,6 @@
          url("ttf/FiraMono-Bold.ttf") format("truetype");
     font-weight: 600;
     font-style: normal;
+    font-display: $font-display;
 }
 

--- a/fira-mono.styl
+++ b/fira-mono.styl
@@ -1,4 +1,5 @@
 /* Fira Mono */
+$font-display ?= swap
 
 @font-face
   font-family: 'Fira Mono'
@@ -6,6 +7,7 @@
   src: local("Fira Mono"), url("eot/FiraMono-Regular.eot") format("embedded-opentype"), url("woff/FiraMono-Regular.woff") format("woff"), url("ttf/FiraMono-Regular.ttf") format("truetype")
   font-weight: 400
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Mono'
@@ -13,4 +15,5 @@
   src: local("Fira Mono Bold"), url("eot/FiraMono-Bold.eot") format("embedded-opentype"), url("woff/FiraMono-Bold.woff") format("woff"), url("ttf/FiraMono-Bold.ttf") format("truetype")
   font-weight: 600
   font-style: normal
+  font-display: $font-display
 

--- a/fira-sans.less
+++ b/fira-sans.less
@@ -1,4 +1,5 @@
 /* Fira Sans specimen */
+@font-display: swap;
 
 @font-face{
     font-family: 'Fira Sans';
@@ -9,6 +10,7 @@
          url('ttf/FiraSans-Light.ttf') format('truetype');
     font-weight: 300;
     font-style: normal;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -20,6 +22,7 @@
          url('ttf/FiraSans-LightItalic.ttf') format('truetype');
     font-weight: 300;
     font-style: italic;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -31,6 +34,7 @@
          url('ttf/FiraSans-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -42,6 +46,7 @@
          url('ttf/FiraSans-RegularItalic.ttf') format('truetype');
     font-weight: 400;
     font-style: italic;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -53,6 +58,7 @@
          url('ttf/FiraSans-Medium.ttf') format('truetype');
     font-weight: 500;
     font-style: normal;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -64,6 +70,7 @@
          url('ttf/FiraSans-MediumItalic.ttf') format('truetype');
     font-weight: 500;
     font-style: italic;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -75,6 +82,7 @@
          url('ttf/FiraSans-Bold.ttf') format('truetype');
     font-weight: 600;
     font-style: normal;
+    font-display: @font-display;
 }
 
 @font-face{
@@ -86,4 +94,5 @@
          url('ttf/FiraSans-BoldItalic.ttf') format('truetype');
     font-weight: 600;
     font-style: italic;
+    font-display: @font-display;
 }

--- a/fira-sans.sass
+++ b/fira-sans.sass
@@ -1,4 +1,5 @@
 // Fira Sans
+$font-display: swap !default
 
 @font-face
   font-family: 'Fira Sans'
@@ -6,6 +7,7 @@
   src: local("Fira Sans Light"), url("eot/FiraSans-Light.eot") format("embedded-opentype"), url("woff/FiraSans-Light.woff") format("woff"), url("ttf/FiraSans-Light.ttf") format("truetype")
   font-weight: 300
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -13,6 +15,7 @@
   src: local("Fira Sans Light Italic"), url("eot/FiraSans-LightItalic.eot") format("embedded-opentype"), url("woff/FiraSans-LightItalic.woff") format("woff"), url("ttf/FiraSans-LightItalic.ttf") format("truetype")
   font-weight: 300
   font-style: italic
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -20,6 +23,7 @@
   src: local("Fira Sans Regular"), url("eot/FiraSans-Regular.eot") format("embedded-opentype"), url("woff/FiraSans-Regular.woff") format("woff"), url("ttf/FiraSans-Regular.ttf") format("truetype")
   font-weight: 400
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -27,6 +31,7 @@
   src: local("Fira Sans Regular Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
   font-weight: 400
   font-style: italic
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -34,6 +39,7 @@
   src: local("Fira Sans Medium"), url("eot/FiraSans-Medium.eot") format("embedded-opentype"), url("woff/FiraSans-Medium.woff") format("woff"), url("ttf/FiraSans-Medium.ttf") format("truetype")
   font-weight: 500
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -41,6 +47,7 @@
   src: local("Fira Sans Medium Italic"), url("eot/FiraSans-MediumItalic.eot") format("embedded-opentype"), url("woff/FiraSans-MediumItalic.woff") format("woff"), url("ttf/FiraSans-MediumItalic.ttf") format("truetype")
   font-weight: 500
   font-style: italic
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -48,6 +55,7 @@
   src: local("Fira Sans Bold"), url("eot/FiraSans-Bold.eot") format("embedded-opentype"), url("woff/FiraSans-Bold.woff") format("woff"), url("ttf/FiraSans-Bold.ttf") format("truetype")
   font-weight: 600
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -55,4 +63,5 @@
   src: local("Fira Sans Bold Italic"), url("eot/FiraSans-BoldItalic.eot") format("embedded-opentype"), url("woff/FiraSans-BoldItalic.woff") format("woff"), url("ttf/FiraSans-BoldItalic.ttf") format("truetype")
   font-weight: 600
   font-style: italic
+  font-display: $font-display
 

--- a/fira-sans.scss
+++ b/fira-sans.scss
@@ -1,4 +1,5 @@
 // Fira Sans
+$font-display: swap !default;
 
 @font-face{
     font-family: 'Fira Sans';
@@ -9,6 +10,7 @@
          url("ttf/FiraSans-Light.ttf") format("truetype");
     font-weight: 300;
     font-style: normal;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -20,6 +22,7 @@
          url("ttf/FiraSans-LightItalic.ttf") format("truetype");
     font-weight: 300;
     font-style: italic;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -31,6 +34,7 @@
          url("ttf/FiraSans-Regular.ttf") format("truetype");
     font-weight: 400;
     font-style: normal;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -42,6 +46,7 @@
          url("ttf/FiraSans-RegularItalic.ttf") format("truetype");
     font-weight: 400;
     font-style: italic;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -53,6 +58,7 @@
          url("ttf/FiraSans-Medium.ttf") format("truetype");
     font-weight: 500;
     font-style: normal;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -64,6 +70,7 @@
          url("ttf/FiraSans-MediumItalic.ttf") format("truetype");
     font-weight: 500;
     font-style: italic;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -75,6 +82,7 @@
          url("ttf/FiraSans-Bold.ttf") format("truetype");
     font-weight: 600;
     font-style: normal;
+    font-display: $font-display;
 }
 
 @font-face{
@@ -86,5 +94,6 @@
          url("ttf/FiraSans-BoldItalic.ttf") format("truetype");
     font-weight: 600;
     font-style: italic;
+    font-display: $font-display;
 }
 

--- a/fira-sans.styl
+++ b/fira-sans.styl
@@ -1,4 +1,5 @@
 /* Fira Sans */
+$font-display ?= swap
 
 @font-face
   font-family: 'Fira Sans'
@@ -6,6 +7,7 @@
   src: local("Fira Sans Light"), url("eot/FiraSans-Light.eot") format("embedded-opentype"), url("woff/FiraSans-Light.woff") format("woff"), url("ttf/FiraSans-Light.ttf") format("truetype")
   font-weight: 300
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -13,6 +15,7 @@
   src: local("Fira Sans Light Italic"), url("eot/FiraSans-LightItalic.eot") format("embedded-opentype"), url("woff/FiraSans-LightItalic.woff") format("woff"), url("ttf/FiraSans-LightItalic.ttf") format("truetype")
   font-weight: 300
   font-style: italic
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -20,6 +23,7 @@
   src: local("Fira Sans Regular"), url("eot/FiraSans-Regular.eot") format("embedded-opentype"), url("woff/FiraSans-Regular.woff") format("woff"), url("ttf/FiraSans-Regular.ttf") format("truetype")
   font-weight: 400
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -27,6 +31,7 @@
   src: local("Fira Sans Regular Italic"), url("eot/FiraSans-RegularItalic.eot") format("embedded-opentype"), url("woff/FiraSans-RegularItalic.woff") format("woff"), url("ttf/FiraSans-RegularItalic.ttf") format("truetype")
   font-weight: 400
   font-style: italic
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -34,6 +39,7 @@
   src: local("Fira Sans Medium"), url("eot/FiraSans-Medium.eot") format("embedded-opentype"), url("woff/FiraSans-Medium.woff") format("woff"), url("ttf/FiraSans-Medium.ttf") format("truetype")
   font-weight: 500
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -41,6 +47,7 @@
   src: local("Fira Sans Medium Italic"), url("eot/FiraSans-MediumItalic.eot") format("embedded-opentype"), url("woff/FiraSans-MediumItalic.woff") format("woff"), url("ttf/FiraSans-MediumItalic.ttf") format("truetype")
   font-weight: 500
   font-style: italic
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -48,6 +55,7 @@
   src: local("Fira Sans Bold"), url("eot/FiraSans-Bold.eot") format("embedded-opentype"), url("woff/FiraSans-Bold.woff") format("woff"), url("ttf/FiraSans-Bold.ttf") format("truetype")
   font-weight: 600
   font-style: normal
+  font-display: $font-display
 
 @font-face
   font-family: 'Fira Sans'
@@ -55,4 +63,5 @@
   src: local("Fira Sans Bold Italic"), url("eot/FiraSans-BoldItalic.eot") format("embedded-opentype"), url("woff/FiraSans-BoldItalic.woff") format("woff"), url("ttf/FiraSans-BoldItalic.ttf") format("truetype")
   font-weight: 600
   font-style: italic
+  font-display: $font-display
 

--- a/fira.css
+++ b/fira.css
@@ -7,6 +7,7 @@
          url('ttf/FiraSans-Hair.ttf') format('truetype');
     font-weight: 100;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -18,6 +19,7 @@
          url('ttf/FiraSans-HairItalic.ttf') format('truetype');
     font-weight: 100;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -29,6 +31,7 @@
          url('ttf/FiraSans-UltraLight.ttf') format('truetype');
     font-weight: 200;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -40,6 +43,7 @@
          url('ttf/FiraSans-UltraLightItalic.ttf') format('truetype');
     font-weight: 200;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -51,6 +55,7 @@
          url('ttf/FiraSans-Light.ttf') format('truetype');
     font-weight: 300;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -62,6 +67,7 @@
          url('ttf/FiraSans-LightItalic.ttf') format('truetype');
     font-weight: 300;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -73,6 +79,7 @@
          url('ttf/FiraSans-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -84,6 +91,7 @@
          url('ttf/FiraSans-Italic.ttf') format('truetype');
     font-weight: 400;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -95,6 +103,7 @@
          url('ttf/FiraSans-Medium.ttf') format('truetype');
     font-weight: 500;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -106,6 +115,7 @@
          url('ttf/FiraSans-MediumItalic.ttf') format('truetype');
     font-weight: 500;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -117,6 +127,7 @@
          url('ttf/FiraSans-SemiBold.ttf') format('truetype');
     font-weight: 600;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -128,6 +139,7 @@
          url('ttf/FiraSans-SemiBoldItalic.ttf') format('truetype');
     font-weight: 600;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -139,6 +151,7 @@
          url('ttf/FiraSans-Bold.ttf') format('truetype');
     font-weight: 700;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -150,6 +163,7 @@
          url('ttf/FiraSans-BoldItalic.ttf') format('truetype');
     font-weight: 700;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -161,6 +175,7 @@
          url('ttf/FiraSans-ExtraBold.ttf') format('truetype');
     font-weight: 800;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -172,6 +187,7 @@
          url('ttf/FiraSans-ExtraBoldItalic.ttf') format('truetype');
     font-weight: 800;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -183,6 +199,7 @@
          url('ttf/FiraSans-Heavy.ttf') format('truetype');
     font-weight: 900;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -194,6 +211,7 @@
          url('ttf/FiraSans-HeavyItalic.ttf') format('truetype');
     font-weight: 900;
     font-style: italic;
+    font-display: var(--font-display, swap);
 }
 
 
@@ -206,6 +224,7 @@
          url('ttf/FiraMono-Regular.ttf') format('truetype');
     font-weight: 400;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 
 @font-face{
@@ -217,5 +236,6 @@
          url('ttf/FiraMono-Bold.ttf') format('truetype');
     font-weight: 600;
     font-style: normal;
+    font-display: var(--font-display, swap);
 }
 

--- a/fira.sass
+++ b/fira.sass
@@ -1,5 +1,5 @@
 // Fira Font Family
 
-@import ./fira-sans.scss
-@import ./fira-mono.scss
+@import ./fira-sans.sass
+@import ./fira-mono.sass
 

--- a/fira.styl
+++ b/fira.styl
@@ -1,5 +1,5 @@
 /* Fira Font Family */
 
-@import './fira-sans.scss'
-@import './fira-mono.scss'
+@import './fira-sans.styl'
+@import './fira-mono.styl'
 


### PR DESCRIPTION
This pull request adds a variable which is used in the [font-display](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization#using_font-display) property and defaults to `swap`.

Here's a usage example for each syntax:

```css
/* CSS */
:root {
  --font-display: block;
}
@import url("fira.css");
```

```sass
/* SASS */
$font-display: block
@import "fira.sass"
```

```scss
/* SCSS */
$font-display: block;
@import "fira.scss";
```

```stylus
/* Stylus */
$font-display = block
@import "fira.styl"
```

```less
/* Less */
@import "fira.less";
@font-display: block;
```

I also took the liberty of fixing the SASS & Stylus imports.