### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mozilla's Fira Type Family
-http://mozilla.github.io/Fira/
+https://mozilla.github.io/Fira/
 
 ## Download Fira
 <a href="https://github.com/mozilla/Fira/releases/latest">Latest Release</a><br>


### PR DESCRIPTION
Changed the "Mozilla's Fira Type Family" link to use https instead of HTTP.

I would also request someone with write access to change the description of the repo to use https instead of HTTP. https://github.com/mozilla/Fira/issues/236